### PR TITLE
Update Pekko and Pekko HTTP versions to 2.0.0-M1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,8 @@ jobs:
           - macos-14
           - macos-latest
           - windows-latest
-        scala: [2.12.21, 2.13.18, 3.3.7]
-        java:
-          - corretto@8
-          - temurin@11
-          - temurin@17
-          - temurin@21
-          - temurin@25
+        scala: [2.13.18, 3.3.7]
+        java: [temurin@17, temurin@21, temurin@25]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ignore line ending differences in git
@@ -53,22 +48,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Setup Java (corretto@8)
-        if: matrix.java == 'corretto@8'
-        uses: actions/setup-java@v5
-        with:
-          distribution: corretto
-          java-version: 8
-          cache: sbt
-
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: sbt
 
       - name: Setup Java (temurin@17)
         if: matrix.java == 'temurin@17'
@@ -139,7 +118,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.18]
-        java: [corretto@8]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ignore line ending differences in git
@@ -158,22 +137,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Setup Java (corretto@8)
-        if: matrix.java == 'corretto@8'
-        uses: actions/setup-java@v5
-        with:
-          distribution: corretto
-          java-version: 8
-          cache: sbt
-
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: sbt
 
       - name: Setup Java (temurin@17)
         if: matrix.java == 'temurin@17'
@@ -201,16 +164,6 @@ jobs:
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
-
-      - name: Download target directories (2.12.21)
-        uses: actions/download-artifact@v6
-        with:
-          name: target-${{ matrix.os }}-2.12.21-${{ matrix.java }}
-
-      - name: Inflate target directories (2.12.21)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
 
       - name: Download target directories (2.13.18)
         uses: actions/download-artifact@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,6 @@ jobs:
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
 
-      - name: Report version policy issues
-        shell: bash
-        run: sbt '++ ${{ matrix.scala }}' versionPolicyCheck
-
       - name: Build project
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' clean coverage test

--- a/build.sbt
+++ b/build.sbt
@@ -3,16 +3,15 @@ import com.jsuereth.sbtpgp.PgpKeys.publishSigned
 name := "pekko-streams-circe"
 
 val scala213Version = "2.13.18"
-val scala212Version = "2.12.21"
 val scala3Version   = "3.3.7"
 
 val circeVersion     = "0.14.15"
-val pekkoVersion     = "1.0.3"
-val pekkoHttpVersion = "1.0.1"
+val pekkoVersion     = "2.0.0-M1"
+val pekkoHttpVersion = "2.0.0-M1"
 val jawnVersion      = "1.6.0"
 val scalaTestVersion = "3.2.20"
 
-ThisBuild / crossScalaVersions     := Seq(scala212Version, scala213Version, scala3Version)
+ThisBuild / crossScalaVersions     := Seq(scala213Version, scala3Version)
 ThisBuild / scalaVersion           := scala213Version
 ThisBuild / organization           := "org.mdedetrich"
 ThisBuild / versionScheme          := Some(VersionScheme.EarlySemVer)
@@ -90,7 +89,7 @@ lazy val tests = project
   .disablePlugins(MimaPlugin)
 
 ThisBuild / scalacOptions ++= Seq(
-  "-release:8",
+  "-release:17",
   "-encoding",
   "UTF-8",
   "-deprecation", // warning and location for usages of deprecated APIs
@@ -201,8 +200,6 @@ ThisBuild / githubWorkflowPublishTargetBranches :=
 ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest", "macos-14", "macos-latest", "windows-latest")
 
 ThisBuild / githubWorkflowJavaVersions := List(
-  JavaSpec.corretto("8"),
-  JavaSpec.temurin("11"),
   JavaSpec.temurin("17"),
   JavaSpec.temurin("21"),
   JavaSpec.temurin("25")

--- a/build.sbt
+++ b/build.sbt
@@ -157,7 +157,8 @@ ThisBuild / scalacOptions ++= {
 ThisBuild / githubWorkflowTargetBranches := Seq("main") // Once we have branches per version, add the pattern here
 
 ThisBuild / githubWorkflowBuild := Seq(
-  WorkflowStep.Sbt(List("versionPolicyCheck"), name = Some("Report version policy issues")),
+  // Temporarily disable version policy check while we switch from Pekko 1.0 to 2.0
+  // WorkflowStep.Sbt(List("versionPolicyCheck"), name = Some("Report version policy issues")),
   WorkflowStep.Sbt(List("clean", "coverage", "test"), name = Some("Build project"))
 )
 


### PR DESCRIPTION
useful to get some sort of release with pekko 2 dependency - this lib is used by pekko-connectors and that repo could do with a release of this module so that we can test pekko 2 generally