### PR TITLE
Remove sbt-sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,7 +113,6 @@ ThisBuild / developers := List(
 ThisBuild / licenses += ("Apache-2.0", url("https://opensource.org/licenses/Apache-2.0"))
 
 ThisBuild / publishMavenStyle      := true
-ThisBuild / publishTo              := sonatypePublishToBundle.value
 ThisBuild / test / publishArtifact := false
 ThisBuild / pomIncludeRepository   := (_ => false)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 addSbtPlugin("com.github.sbt"                    % "sbt-pgp"            % "2.3.1")
-addSbtPlugin("org.xerial.sbt"                    % "sbt-sonatype"       % "3.12.2")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"   % "3.0.2")
 addSbtPlugin("com.github.sbt"                    % "sbt-ci-release"     % "1.11.2")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"       % "2.6.0")


### PR DESCRIPTION
sbt-sonatype is no longer used for publishing to maven ever since the deprecation of OSSH (see https://github.com/xerial/sbt-sonatype#sbt-sonatype-plugin)